### PR TITLE
Fix matches with multiple keys and update tests

### DIFF
--- a/elastalert_hive_alerter/hive_alerter.py
+++ b/elastalert_hive_alerter/hive_alerter.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
+import re
 import uuid
 
 from elastalert.alerts import Alerter
@@ -31,7 +32,8 @@ class HiveAlerter(Alerter):
             for mapping in self.rule.get('hive_observable_data_mapping', []):
                 for observable_type, match_data_key in mapping.iteritems():
                     try:
-                        if match_data_key.replace("{match[","").replace("]}","") in context['match']:
+                        match_data_keys = re.findall(r'\{match\[([^\]]*)\]', match_data_key)
+                        if all([True for k in match_data_keys if k in context['match']]):
                             artifacts.append(AlertArtifact(dataType=observable_type, data=match_data_key.format(**context)))
                     except KeyError:
                         raise KeyError('\nformat string\n{}\nmatch data\n{}'.format(match_data_key, context))


### PR DESCRIPTION
This is a fix for the problem raised in issue #3. It looks like code was added to confirm that match keys are in the context before adding an artifact, but that code did not take into account the possibility that there could be multiple match keys in one observable mapping. I've updated the tests so that they work again and added a new test case for more deeply nested match data.